### PR TITLE
fix: align test renderer to React 18 and remove invalid expo-vector-icons

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,16 @@
+# Dependency update runbook
+
+The following PowerShell commands refresh dependencies and resolve peer conflicts.
+
+```powershell
+Remove-Item -Recurse -Force node_modules, package-lock.json
+npm install
+npx expo install react-native-safe-area-context react-native-screens react-native-gesture-handler react-native-reanimated @expo/vector-icons
+npx expo start -c
+```
+
+If npm still complains, try the temporary workaround:
+
+```powershell
+npm install --legacy-peer-deps
+```

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@react-navigation/bottom-tabs": "^6.5.8",
     "@react-navigation/native-stack": "^6.9.12",
     "react-native-safe-area-context": "^4.6.3",
-    "expo-vector-icons": "^13.0.0",
+    "@expo/vector-icons": "*",
     "zustand": "^4.5.2",
     "@tanstack/react-query": "^5.0.0",
     "axios": "^1.5.0",
@@ -30,6 +30,7 @@
     "@types/react-native": "0.73.0",
     "typescript": "5.2.2",
     "@testing-library/react-native": "^12.1.4",
+    "react-test-renderer": "18.2.0",
     "jest": "^29.6.1",
     "ts-jest": "^29.1.0",
     "@types/jest": "^29.5.5"


### PR DESCRIPTION
## Summary
- replace `expo-vector-icons` with `@expo/vector-icons`
- pin `react-test-renderer` to React 18
- add runbook with PowerShell commands for dependency refresh

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@expo%2fvector-icons)*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ae27f1688320ab34c6975c9c66b5